### PR TITLE
VAST: add cache buster

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maestro-react-player",
-  "version": "1.2.16",
+  "version": "1.2.17",
   "description": "A React component for playing a variety of URLs, including file paths, YouTube, Facebook, Twitch, SoundCloud, Streamable, Vimeo, Wistia and DailyMotion",
   "main": "lib/ReactPlayer.js",
   "typings": "index.d.ts",

--- a/src/players/VAST.js
+++ b/src/players/VAST.js
@@ -50,7 +50,11 @@ export class VAST extends Component {
     }
   }
 
-  load (url) {
+  load (rawUrl) {
+    // replace [RANDOM] or [random] with a randomly generated cache value
+    const ord = Math.random() * 10000000000000000
+    const url = rawUrl.replace(/\[random]/ig, ord)
+
     vast.client.get(url.slice('VAST:'.length), { withCredentials: true }, (response, error) => {
       if (error) {
         return this.props.onError(error)


### PR DESCRIPTION
wrike: https://www.wrike.com/open.htm?id=287740995

replace [random] or [RANDOM] in VAST URL string with randomly generated number

Signed-off-by: Steven Anderson <steven@sjanderson.org>