### PR TITLE
Phenix player: disable console logging

### DIFF
--- a/src/players/PhenixPlayer.js
+++ b/src/players/PhenixPlayer.js
@@ -127,6 +127,7 @@ export class PhenixPlayer extends Component {
       }
       this.channelExpress = new phenix.express.ChannelExpress({
         authenticationData,
+        disableConsoleLogging: true,
         backendUri
       })
       this.channelExpress.joinChannel(


### PR DESCRIPTION
The volume is too damn high

_However_, the sdk logs did help us debug a stream issue with phenix recently.. 

TODO: make sure this does not disable surfacing errors

<img width="1419" alt="phenix-error" src="https://user-images.githubusercontent.com/14230730/71691261-b75fbc80-2d5b-11ea-8af2-ba97412c0e03.png">
